### PR TITLE
Use universal zenodo badge for the README file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,8 +2,8 @@
     :target: https://travis-ci.org/wind-python/windpowerlib
 .. image:: https://coveralls.io/repos/github/wind-python/windpowerlib/badge.svg?branch=dev
     :target: https://coveralls.io/github/wind-python/windpowerlib?branch=dev
-.. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.2542896.svg
-   :target: https://doi.org/10.5281/zenodo.2542896
+.. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.824267.svg
+   :target: https://doi.org/10.5281/zenodo.824267
    
 Introduction
 =============


### PR DESCRIPTION
At the moment the badge points to a specific version but it is possible to use an universal badge that always points to the most actual version. At the moment the badge on the tag v0.1.0 points to version v0.0.6.

[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.824267.svg)](https://doi.org/10.5281/zenodo.824267)
