### PR TITLE
Fix pandas version bug

### DIFF
--- a/example/modelchain_example.py
+++ b/example/modelchain_example.py
@@ -79,10 +79,9 @@ def get_weather_data(filename='weather.csv', **kwargs):
     weather_df.index = pd.to_datetime(weather_df.index).tz_convert(
         'Europe/Berlin')
     # change type of height from str to int by resetting columns
-    weather_df.columns = [weather_df.axes[1].levels[0][
-                              weather_df.axes[1].codes[0]],
-                          weather_df.axes[1].levels[1][
-                              weather_df.axes[1].codes[1]].astype(int)]
+    l0 = [_[0] for _ in weather_df.columns]
+    l1 = [int(_[1]) for _ in weather_df.columns]
+    weather_df.columns = [l0, l1]
     return weather_df
 
 

--- a/windpowerlib/wake_losses.py
+++ b/windpowerlib/wake_losses.py
@@ -120,8 +120,7 @@ def get_wind_efficiency_curve(curve_name='all'):
     else:
         curve_names = curve_name
 
-    efficiency_curve = pd.DataFrame(columns=pd.MultiIndex(levels=[[], []],
-                                                          codes=[[], []]))
+    efficiency_curve = pd.DataFrame()
 
     for curve_name in curve_names:
         if curve_name.split('_')[0] not in ['dena', 'knorr']:
@@ -142,8 +141,13 @@ def get_wind_efficiency_curve(curve_name='all'):
 
         # Get wind efficiency curve and rename column containing efficiency
         wec = wind_efficiency_curves[['wind_speed', curve_name]]
-        efficiency_curve[curve_name, 'wind_speed'] = wec['wind_speed']
-        efficiency_curve[curve_name, 'efficiency'] = wec[curve_name]
+        if efficiency_curve.empty:
+            efficiency_curve = pd.DataFrame(
+                {(curve_name, 'wind_speed'): wec['wind_speed'],
+                 (curve_name, 'efficiency'): wec[curve_name]})
+        else:
+            efficiency_curve[(curve_name, 'wind_speed')] = wec['wind_speed']
+            efficiency_curve[(curve_name, 'efficiency')] = wec[curve_name]
     if len(curve_names) == 1:
         return efficiency_curve[curve_names[0]]
     else:


### PR DESCRIPTION
labels attribute of pandas MultiIndex is deprecated as of pandas version 0.24. This was fixed in this [commit](https://github.com/wind-python/windpowerlib/commit/400ed99d7e67ce714068d76e7a1f303d0c6f0496#diff-9df918c3ae5b1ec154a04600cae8bfbf). However, using codes instead of labels seems to only work with pandas version >0.24. To allow using older pandas versions and avoid incompatibilities with oemof, that only allows pandas < 0.24 I added a work around in two places of the windpowerlib. This also fixes #50.


