### PR TITLE
Round values in total_capacity check

### DIFF
--- a/windpowerlib/wind_farm.py
+++ b/windpowerlib/wind_farm.py
@@ -177,9 +177,9 @@ class WindFarm(object):
                         'wind turbine is set.'.format(
                             turbine=row['wind_turbine']))
             else:
-                if not round(row['total_capacity'], 3) == round(
+                if not abs(row['total_capacity'] - (
                         row['number_of_turbines'] *
-                        row['wind_turbine'].nominal_power, 3):
+                        row['wind_turbine'].nominal_power)) < 1:
                     self.wind_turbine_fleet.loc[ix, 'total_capacity'] = \
                         row['number_of_turbines'] * \
                         row['wind_turbine'].nominal_power

--- a/windpowerlib/wind_farm.py
+++ b/windpowerlib/wind_farm.py
@@ -177,9 +177,9 @@ class WindFarm(object):
                         'wind turbine is set.'.format(
                             turbine=row['wind_turbine']))
             else:
-                if not row['total_capacity'] == (
+                if not round(row['total_capacity'], 3) == round(
                         row['number_of_turbines'] *
-                        row['wind_turbine'].nominal_power):
+                        row['wind_turbine'].nominal_power, 3):
                     self.wind_turbine_fleet.loc[ix, 'total_capacity'] = \
                         row['number_of_turbines'] * \
                         row['wind_turbine'].nominal_power


### PR DESCRIPTION
WindpowerlibUserWarning were raised due to differences in `total_capacity` in 4th or 5th decimal place.
Rounding could even be done up to 1st or 2nd decimal place; unit of `total_capacity` is W.