### PR TITLE
Remove get_installed_power method

### DIFF
--- a/doc/modules.rst
+++ b/doc/modules.rst
@@ -93,7 +93,7 @@ as the aggregated power curve of a :py:class:`~.wind_farm.WindFarm` object.
 Wind turbine cluster calculations
 =================================
 
-Functions and methods to calculate the mean hub height, installed power as well
+Functions and methods to calculate the mean hub height, nominal power as well
 as the aggregated power curve of a :py:class:`~.wind_turbine_cluster.WindTurbineCluster` object.
 This is realized in a new module as the functions differ from the functions in
 the :py:class:`~.wind_farm.WindFarm` class.
@@ -103,7 +103,6 @@ the :py:class:`~.wind_farm.WindFarm` class.
 
    wind_turbine_cluster.WindTurbineCluster.nominal_power
    wind_turbine_cluster.WindTurbineCluster.mean_hub_height
-   wind_turbine_cluster.WindTurbineCluster.get_installed_power
    wind_turbine_cluster.WindTurbineCluster.assign_power_curve
 
 .. _poweroutput_module_label:

--- a/doc/whatsnew/v0-2-0.txt
+++ b/doc/whatsnew/v0-2-0.txt
@@ -23,6 +23,7 @@ API changes
 * Combined options 'constant_efficiency' and 'power_efficiency_curve' of `wake_losses_model` parameter in :py:func:`~.turbine_cluster_modelchain.TurbineClusterModelChain` to 'wind_farm_efficiency'. Therefore, default value of `wake_losses_model` in :py:func:`~.wind_farm.WindFarm.assign_power_curve` and :py:func:`~.wind_turbine_cluster.WindTurbineCluster.assign_power_curve` changed to 'wind_farm_efficiency'.
 * Removed `overwrite` parameter from :py:func:`~.wind_turbine.get_turbine_data_from_oedb`
 * Removed `data_source` and `fetch_curve` parameters from :py:func:`~.wind_turbine.WindTurbine` and :py:func:`~.wind_turbine.WindTurbine.fetch_turbine_data`. Now the source and if a curve is fetched or not is specified by the parameters `power_curve`, `power_coefficient_curve` and `nominal_power`. See :py:func:`~.wind_turbine.WindTurbine.fetch_turbine_data` for a description.
+* get_installed_power() methods in :class:`~windpowerlib.wind_farm.WindFarm` and  :class:`~windpowerlib.wind_turbine_cluster.WindTurbineCluster` were removed. Installed power is instead now directly calculated inside the nominal_power getter.
 
 Other changes
 #############
@@ -36,4 +37,5 @@ Deprecations
 Contributors
 ############
 * Sabine Haas
+* Birgit Schachler
 

--- a/windpowerlib/wind_turbine_cluster.py
+++ b/windpowerlib/wind_turbine_cluster.py
@@ -83,7 +83,8 @@ class WindTurbineCluster(object):
 
         """
         if not self._nominal_power:
-            self.nominal_power = self.get_installed_power()
+            self.nominal_power = sum(wind_farm.nominal_power
+                                     for wind_farm in self.wind_farms)
         return self._nominal_power
 
     @nominal_power.setter
@@ -130,21 +131,6 @@ class WindTurbineCluster(object):
             np.log(wind_farm.hub_height) * wind_farm.nominal_power for
             wind_farm in self.wind_farms) / self.nominal_power)
         return self
-
-    def get_installed_power(self):
-        r"""
-        Calculates the :py:attr:`~nominal_power` of a wind turbine cluster.
-
-        Returns
-        -------
-        float
-            Nominal power of the wind farm in W. See :py:attr:`~nominal_power`
-            for further information.
-
-        """
-        for wind_farm in self.wind_farms:
-            wind_farm.nominal_power = wind_farm.nominal_power
-        return sum(wind_farm.nominal_power for wind_farm in self.wind_farms)
 
     def assign_power_curve(self, wake_losses_model='wind_farm_efficiency',
                            smoothing=False, block_width=0.5,


### PR DESCRIPTION
Changes proposed in this pull request:
- get_installed_power method is removed from WindTurbineCluster class and content moved to nominal_power getter.


