### PR TITLE
Fix license inconsistency

### DIFF
--- a/example/modelchain_example.ipynb
+++ b/example/modelchain_example.ipynb
@@ -4,6 +4,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "SPDX-FileCopyrightText: 2019 oemof developer group <contact@oemof.org>\n",
+    "\n",
+    "SPDX-License-Identifier: MIT\n",
+    "\n",
+    "SPDX-License-Identifier: CC-BY-4.0"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# ModelChain example\n",
     "\n",
     "This example shows you the basic usage of the windpowerlib by using the ``ModelChain`` class.\n",
@@ -564,7 +575,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,

--- a/example/modelchain_example.ipynb
+++ b/example/modelchain_example.ipynb
@@ -25,9 +25,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "__copyright__ = \"Copyright oemof developer group\"\n",
-    "__license__ = \"GPLv3\"\n",
-    "\n",
     "import os\n",
     "import pandas as pd\n",
     "\n",

--- a/example/modelchain_example.py
+++ b/example/modelchain_example.py
@@ -10,7 +10,8 @@ There are mainly three steps. First you have to import your weather data, then
 you need to specify your wind turbine, and in the last step call the
 windpowerlib functions to calculate the feed-in time series.
 
-
+SPDX-FileCopyrightText: 2019 oemof developer group <contact@oemof.org>
+SPDX-License-Identifier: MIT
 """
 import os
 import pandas as pd

--- a/example/modelchain_example.py
+++ b/example/modelchain_example.py
@@ -12,10 +12,6 @@ windpowerlib functions to calculate the feed-in time series.
 
 
 """
-
-__copyright__ = "Copyright oemof developer group"
-__license__ = "GPLv3"
-
 import os
 import pandas as pd
 

--- a/example/test_examples.py
+++ b/example/test_examples.py
@@ -1,3 +1,8 @@
+"""
+SPDX-FileCopyrightText: 2019 oemof developer group <contact@oemof.org>
+SPDX-License-Identifier: MIT
+"""
+
 import os
 import subprocess
 import tempfile

--- a/example/turbine_cluster_modelchain_example.ipynb
+++ b/example/turbine_cluster_modelchain_example.ipynb
@@ -26,9 +26,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "__copyright__ = \"Copyright oemof developer group\"\n",
-    "__license__ = \"GPLv3\"\n",
-    "\n",
     "import pandas as pd\n",
     "\n",
     "import modelchain_example as mc_e\n",
@@ -342,7 +339,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.6.8"
   }
  },
  "nbformat": 4,

--- a/example/turbine_cluster_modelchain_example.ipynb
+++ b/example/turbine_cluster_modelchain_example.ipynb
@@ -4,6 +4,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "SPDX-FileCopyrightText: 2019 oemof developer group <contact@oemof.org>\n",
+    "\n",
+    "SPDX-License-Identifier: MIT\n",
+    "\n",
+    "SPDX-License-Identifier: CC-BY-4.0"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# TurbineClusterModelChain example\n",
     "\n",
     "This example shows you how to calculate the power output of wind farms and wind turbine clusters using the windpowerlib. A cluster can be useful if you want to calculate the feed-in of a region for which you want to use one single weather data point.\n",

--- a/example/turbine_cluster_modelchain_example.py
+++ b/example/turbine_cluster_modelchain_example.py
@@ -7,6 +7,8 @@ which you want to use one single weather data point.
 Functions that are used in the ``modelchain_example``, like the initialization
 of wind turbines, are imported and used without further explanations.
 
+SPDX-FileCopyrightText: 2019 oemof developer group <contact@oemof.org>
+SPDX-License-Identifier: MIT
 """
 import pandas as pd
 

--- a/example/turbine_cluster_modelchain_example.py
+++ b/example/turbine_cluster_modelchain_example.py
@@ -8,10 +8,6 @@ Functions that are used in the ``modelchain_example``, like the initialization
 of wind turbines, are imported and used without further explanations.
 
 """
-
-__copyright__ = "Copyright oemof developer group"
-__license__ = "GPLv3"
-
 import pandas as pd
 
 try:

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(name='windpowerlib',
       url='http://github.com/wind-python/windpowerlib',
       author='oemof developer group',
       author_email='windpowerlib@rl-institut.de',
-      license=None,
+      license='MIT',
       packages=['windpowerlib'],
       package_data={
           'windpowerlib': [os.path.join('data', '*.csv'),

--- a/tests/test_density.py
+++ b/tests/test_density.py
@@ -1,3 +1,8 @@
+"""
+SPDX-FileCopyrightText: 2019 oemof developer group <contact@oemof.org>
+SPDX-License-Identifier: MIT
+"""
+
 import pandas as pd
 import numpy as np
 from pandas.util.testing import assert_series_equal

--- a/tests/test_modelchain.py
+++ b/tests/test_modelchain.py
@@ -1,10 +1,6 @@
 """
 Testing the ``modelchain`` module.
 """
-
-__copyright__ = "Copyright oemof developer group"
-__license__ = "GPLv3"
-
 import pandas as pd
 import numpy as np
 import pytest

--- a/tests/test_modelchain.py
+++ b/tests/test_modelchain.py
@@ -1,5 +1,8 @@
 """
 Testing the ``modelchain`` module.
+
+SPDX-FileCopyrightText: 2019 oemof developer group <contact@oemof.org>
+SPDX-License-Identifier: MIT
 """
 import pandas as pd
 import numpy as np

--- a/tests/test_power_curves.py
+++ b/tests/test_power_curves.py
@@ -1,3 +1,8 @@
+"""
+SPDX-FileCopyrightText: 2019 oemof developer group <contact@oemof.org>
+SPDX-License-Identifier: MIT
+"""
+
 import pandas as pd
 import numpy as np
 import pytest

--- a/tests/test_power_output.py
+++ b/tests/test_power_output.py
@@ -1,3 +1,8 @@
+"""
+SPDX-FileCopyrightText: 2019 oemof developer group <contact@oemof.org>
+SPDX-License-Identifier: MIT
+"""
+
 import pandas as pd
 import numpy as np
 import pytest

--- a/tests/test_temperature.py
+++ b/tests/test_temperature.py
@@ -1,3 +1,8 @@
+"""
+SPDX-FileCopyrightText: 2019 oemof developer group <contact@oemof.org>
+SPDX-License-Identifier: MIT
+"""
+
 import pandas as pd
 import numpy as np
 from pandas.util.testing import assert_series_equal

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,3 +1,8 @@
+"""
+SPDX-FileCopyrightText: 2019 oemof developer group <contact@oemof.org>
+SPDX-License-Identifier: MIT
+"""
+
 import pandas as pd
 from pandas.util.testing import assert_series_equal
 

--- a/tests/test_turbine_cluster_modelchain.py
+++ b/tests/test_turbine_cluster_modelchain.py
@@ -1,3 +1,8 @@
+"""
+SPDX-FileCopyrightText: 2019 oemof developer group <contact@oemof.org>
+SPDX-License-Identifier: MIT
+"""
+
 import pytest
 import pandas as pd
 import numpy as np

--- a/tests/test_wake_losses.py
+++ b/tests/test_wake_losses.py
@@ -1,3 +1,8 @@
+"""
+SPDX-FileCopyrightText: 2019 oemof developer group <contact@oemof.org>
+SPDX-License-Identifier: MIT
+"""
+
 import pandas as pd
 import numpy as np
 import pytest

--- a/tests/test_wind_farm.py
+++ b/tests/test_wind_farm.py
@@ -1,3 +1,8 @@
+"""
+SPDX-FileCopyrightText: 2019 oemof developer group <contact@oemof.org>
+SPDX-License-Identifier: MIT
+"""
+
 import pytest
 import pandas as pd
 import numpy as np

--- a/tests/test_wind_speed.py
+++ b/tests/test_wind_speed.py
@@ -1,3 +1,8 @@
+"""
+SPDX-FileCopyrightText: 2019 oemof developer group <contact@oemof.org>
+SPDX-License-Identifier: MIT
+"""
+
 import pandas as pd
 import numpy as np
 import pytest

--- a/tests/test_wind_turbine.py
+++ b/tests/test_wind_turbine.py
@@ -1,10 +1,6 @@
 """
 Testing the wind_turbine module.
 """
-
-__copyright__ = "Copyright oemof developer group"
-__license__ = "GPLv3"
-
 import pytest
 import os
 from windpowerlib.tools import WindpowerlibUserWarning

--- a/tests/test_wind_turbine.py
+++ b/tests/test_wind_turbine.py
@@ -1,6 +1,10 @@
 """
 Testing the wind_turbine module.
+
+SPDX-FileCopyrightText: 2019 oemof developer group <contact@oemof.org>
+SPDX-License-Identifier: MIT
 """
+
 import pytest
 import os
 from windpowerlib.tools import WindpowerlibUserWarning

--- a/windpowerlib/__init__.py
+++ b/windpowerlib/__init__.py
@@ -1,5 +1,5 @@
 __copyright__ = "Copyright oemof developer group"
-__license__ = "GPLv3"
+__license__ = "MIT"
 __version__ = '0.2.1dev'
 
 from windpowerlib.wind_turbine import WindTurbine

--- a/windpowerlib/density.py
+++ b/windpowerlib/density.py
@@ -4,9 +4,6 @@ temperature at hub height of a wind turbine.
 
 """
 
-__copyright__ = "Copyright oemof developer group"
-__license__ = "GPLv3"
-
 
 def barometric(pressure, pressure_height, hub_height, temperature_hub_height):
     r"""

--- a/windpowerlib/density.py
+++ b/windpowerlib/density.py
@@ -2,6 +2,8 @@
 The ``density`` module contains functions to calculate the density and
 temperature at hub height of a wind turbine.
 
+SPDX-FileCopyrightText: 2019 oemof developer group <contact@oemof.org>
+SPDX-License-Identifier: MIT
 """
 
 

--- a/windpowerlib/modelchain.py
+++ b/windpowerlib/modelchain.py
@@ -3,6 +3,8 @@ The ``modelchain`` module contains functions and classes of the
 windpowerlib. This module makes it easy to get started with the windpowerlib
 and demonstrates standard ways to use the library.
 
+SPDX-FileCopyrightText: 2019 oemof developer group <contact@oemof.org>
+SPDX-License-Identifier: MIT
 """
 import logging
 from windpowerlib import (wind_speed, density, temperature, power_output,

--- a/windpowerlib/modelchain.py
+++ b/windpowerlib/modelchain.py
@@ -4,10 +4,6 @@ windpowerlib. This module makes it easy to get started with the windpowerlib
 and demonstrates standard ways to use the library.
 
 """
-
-__copyright__ = "Copyright oemof developer group"
-__license__ = "GPLv3"
-
 import logging
 from windpowerlib import (wind_speed, density, temperature, power_output,
                           tools)

--- a/windpowerlib/power_curves.py
+++ b/windpowerlib/power_curves.py
@@ -4,10 +4,6 @@ power curve smoothing or reducing power values by an efficiency to the power
 curve of a wind turbine, wind farm or wind turbine cluster.
 
 """
-
-__copyright__ = "Copyright oemof developer group"
-__license__ = "GPLv3"
-
 import numpy as np
 import pandas as pd
 from windpowerlib import tools

--- a/windpowerlib/power_curves.py
+++ b/windpowerlib/power_curves.py
@@ -3,6 +3,8 @@ The ``power_curves`` module contains functions for applying alterations like
 power curve smoothing or reducing power values by an efficiency to the power
 curve of a wind turbine, wind farm or wind turbine cluster.
 
+SPDX-FileCopyrightText: 2019 oemof developer group <contact@oemof.org>
+SPDX-License-Identifier: MIT
 """
 import numpy as np
 import pandas as pd

--- a/windpowerlib/power_output.py
+++ b/windpowerlib/power_output.py
@@ -2,6 +2,8 @@
 The ``power_output`` module contains functions to calculate the power output
 of a wind turbine.
 
+SPDX-FileCopyrightText: 2019 oemof developer group <contact@oemof.org>
+SPDX-License-Identifier: MIT
 """
 import numpy as np
 import pandas as pd

--- a/windpowerlib/power_output.py
+++ b/windpowerlib/power_output.py
@@ -3,10 +3,6 @@ The ``power_output`` module contains functions to calculate the power output
 of a wind turbine.
 
 """
-
-__copyright__ = "Copyright oemof developer group"
-__license__ = "GPLv3"
-
 import numpy as np
 import pandas as pd
 

--- a/windpowerlib/temperature.py
+++ b/windpowerlib/temperature.py
@@ -2,6 +2,8 @@
 The ``temperature`` module contains functions to calculate the temperature at
 hub height of a wind turbine.
 
+SPDX-FileCopyrightText: 2019 oemof developer group <contact@oemof.org>
+SPDX-License-Identifier: MIT
 """
 
 

--- a/windpowerlib/temperature.py
+++ b/windpowerlib/temperature.py
@@ -4,9 +4,6 @@ hub height of a wind turbine.
 
 """
 
-__copyright__ = "Copyright oemof developer group"
-__license__ = "GPLv3"
-
 
 def linear_gradient(temperature, temperature_height, hub_height):
     r"""

--- a/windpowerlib/tools.py
+++ b/windpowerlib/tools.py
@@ -2,6 +2,8 @@
 The ``tools`` module contains a collection of helper functions used in the
 windpowerlib.
 
+SPDX-FileCopyrightText: 2019 oemof developer group <contact@oemof.org>
+SPDX-License-Identifier: MIT
 """
 import numpy as np
 import warnings

--- a/windpowerlib/tools.py
+++ b/windpowerlib/tools.py
@@ -3,11 +3,6 @@ The ``tools`` module contains a collection of helper functions used in the
 windpowerlib.
 
 """
-
-
-__copyright__ = "Copyright oemof developer group"
-__license__ = "GPLv3"
-
 import numpy as np
 import warnings
 

--- a/windpowerlib/turbine_cluster_modelchain.py
+++ b/windpowerlib/turbine_cluster_modelchain.py
@@ -5,10 +5,6 @@ and shows use cases for the power output calculation of wind farms and wind
 turbine clusters.
 
 """
-
-__copyright__ = "Copyright oemof developer group"
-__license__ = "GPLv3"
-
 import logging
 from windpowerlib import wake_losses
 from windpowerlib.modelchain import ModelChain

--- a/windpowerlib/turbine_cluster_modelchain.py
+++ b/windpowerlib/turbine_cluster_modelchain.py
@@ -4,6 +4,8 @@ windpowerlib. This module makes it easy to get started with the windpowerlib
 and shows use cases for the power output calculation of wind farms and wind
 turbine clusters.
 
+SPDX-FileCopyrightText: 2019 oemof developer group <contact@oemof.org>
+SPDX-License-Identifier: MIT
 """
 import logging
 from windpowerlib import wake_losses

--- a/windpowerlib/wake_losses.py
+++ b/windpowerlib/wake_losses.py
@@ -3,10 +3,6 @@ The ``wake_losses`` module contains functions for modelling wake losses by wind
 efficiency curves (reduction of wind speed).
 
 """
-
-__copyright__ = "Copyright oemof developer group"
-__license__ = "GPLv3"
-
 import numpy as np
 import pandas as pd
 import os

--- a/windpowerlib/wake_losses.py
+++ b/windpowerlib/wake_losses.py
@@ -2,6 +2,8 @@
 The ``wake_losses`` module contains functions for modelling wake losses by wind
 efficiency curves (reduction of wind speed).
 
+SPDX-FileCopyrightText: 2019 oemof developer group <contact@oemof.org>
+SPDX-License-Identifier: MIT
 """
 import numpy as np
 import pandas as pd

--- a/windpowerlib/wind_farm.py
+++ b/windpowerlib/wind_farm.py
@@ -4,10 +4,6 @@ a wind farm in the windpowerlib and functions needed for the modelling of a
 wind farm.
 
 """
-
-__copyright__ = "Copyright oemof developer group"
-__license__ = "GPLv3"
-
 from windpowerlib import tools, power_curves, WindTurbine
 import numpy as np
 import pandas as pd

--- a/windpowerlib/wind_farm.py
+++ b/windpowerlib/wind_farm.py
@@ -3,6 +3,8 @@ The ``wind_farm`` module contains the class WindFarm that implements
 a wind farm in the windpowerlib and functions needed for the modelling of a
 wind farm.
 
+SPDX-FileCopyrightText: 2019 oemof developer group <contact@oemof.org>
+SPDX-License-Identifier: MIT
 """
 from windpowerlib import tools, power_curves, WindTurbine
 import numpy as np

--- a/windpowerlib/wind_speed.py
+++ b/windpowerlib/wind_speed.py
@@ -3,10 +3,6 @@ The ``wind_speed`` module contains functions to calculate the wind speed at
 hub height of a wind turbine.
 
 """
-
-__copyright__ = "Copyright oemof developer group"
-__license__ = "GPLv3"
-
 import numpy as np
 import pandas as pd
 

--- a/windpowerlib/wind_speed.py
+++ b/windpowerlib/wind_speed.py
@@ -2,6 +2,8 @@
 The ``wind_speed`` module contains functions to calculate the wind speed at
 hub height of a wind turbine.
 
+SPDX-FileCopyrightText: 2019 oemof developer group <contact@oemof.org>
+SPDX-License-Identifier: MIT
 """
 import numpy as np
 import pandas as pd

--- a/windpowerlib/wind_turbine.py
+++ b/windpowerlib/wind_turbine.py
@@ -3,6 +3,8 @@ The ``wind_turbine`` module contains the class WindTurbine that implements
 a wind turbine in the windpowerlib and functions needed for the modelling of a
 wind turbine.
 
+SPDX-FileCopyrightText: 2019 oemof developer group <contact@oemof.org>
+SPDX-License-Identifier: MIT
 """
 import pandas as pd
 import logging

--- a/windpowerlib/wind_turbine.py
+++ b/windpowerlib/wind_turbine.py
@@ -4,10 +4,6 @@ a wind turbine in the windpowerlib and functions needed for the modelling of a
 wind turbine.
 
 """
-
-__copyright__ = "Copyright oemof developer group"
-__license__ = "GPLv3"
-
 import pandas as pd
 import logging
 import warnings

--- a/windpowerlib/wind_turbine_cluster.py
+++ b/windpowerlib/wind_turbine_cluster.py
@@ -5,6 +5,8 @@ needed for modelling a wind turbine cluster.
 A wind turbine cluster comprises wind farms and wind turbines belonging to the
 same weather data point.
 
+SPDX-FileCopyrightText: 2019 oemof developer group <contact@oemof.org>
+SPDX-License-Identifier: MIT
 """
 import numpy as np
 import pandas as pd

--- a/windpowerlib/wind_turbine_cluster.py
+++ b/windpowerlib/wind_turbine_cluster.py
@@ -6,11 +6,6 @@ A wind turbine cluster comprises wind farms and wind turbines belonging to the
 same weather data point.
 
 """
-
-__copyright__ = "Copyright oemof developer group"
-__license__ = "GPLv3"
-
-
 import numpy as np
 import pandas as pd
 


### PR DESCRIPTION
Changes proposed in this pull request:

As I see it, at the moment there are three different licenses for `windpowerlib` which is confusing and could be a "showstopper" for many users and companies that would like to work with this software

1. MIT license in the LICENSE file
2. GPL3v in the source code of the ``.py`` files
3. `license=None` in the ``setup.py`` which could mean that there is no license for this software and implies that there are no terms of usage and defaults to "no one can use the software" (see [here](https://choosealicense.com/no-permission/)).

Value of ``__license__`` variable is not consistent with PR #77. I suggest moving license information to ``setup.py`` which can be used by Distutils and removing the ``__copyright__`` variable since it is a part of README.md and holds for the whole project.

Fixes #77 and #78