### PR TITLE
Add Binder to the project

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,6 +4,8 @@
     :target: https://coveralls.io/github/wind-python/windpowerlib?branch=dev
 .. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.824267.svg
    :target: https://doi.org/10.5281/zenodo.824267
+.. image:: https://mybinder.org/badge_logo.svg
+ :target: https://mybinder.org/v2/gh/wind-python/windpowerlib/dev?filepath=example
    
 Introduction
 =============
@@ -50,26 +52,28 @@ Matplotlib can be installed using pip:
 Examples and basic usage
 =========================
 
+The simplest way to run the example notebooks without installing windpowerlib is to click `here <https://mybinder.org/v2/gh/wind-python/windpowerlib/dev?filepath=example>`_ and open them with Binder.
+
 The basic usage of the windpowerlib is shown in the `ModelChain example <http://windpowerlib.readthedocs.io/en/stable/modelchain_example_notebook.html>`_ that is available as jupyter notebook and python script:
 
- * `ModelChain example (Python script) <https://raw.githubusercontent.com/wind-python/windpowerlib/master/example/modelchain_example.py>`_
- * `ModelChain example (Jupyter notebook) <https://raw.githubusercontent.com/wind-python/windpowerlib/master/example/modelchain_example.ipynb>`_
+* `ModelChain example (Python script) <https://raw.githubusercontent.com/wind-python/windpowerlib/master/example/modelchain_example.py>`_
+* `ModelChain example (Jupyter notebook) <https://raw.githubusercontent.com/wind-python/windpowerlib/master/example/modelchain_example.ipynb>`_
 
 To run the example you need the example weather and turbine data used:
 
- * `Example weather data file <https://raw.githubusercontent.com/wind-python/windpowerlib/master/example/weather.csv>`_
- * `Example power curve data file <https://raw.githubusercontent.com/wind-python/windpowerlib/master/example/data/example_power_curves.csv>`_
- * `Example power coefficient curve data file <https://raw.githubusercontent.com/wind-python/windpowerlib/master/example/data/example_power_coefficient_curves.csv>`_
- * `Example nominal power data file <https://raw.githubusercontent.com/wind-python/windpowerlib/master/example/data/example_turbine_data.csv>`_
+* `Example weather data file <https://raw.githubusercontent.com/wind-python/windpowerlib/master/example/weather.csv>`_
+* `Example power curve data file <https://raw.githubusercontent.com/wind-python/windpowerlib/master/example/data/example_power_curves.csv>`_
+* `Example power coefficient curve data file <https://raw.githubusercontent.com/wind-python/windpowerlib/master/example/data/example_power_coefficient_curves.csv>`_
+* `Example nominal power data file <https://raw.githubusercontent.com/wind-python/windpowerlib/master/example/data/example_turbine_data.csv>`_
 
-Furthermore, you have to install the windpowerlib. To run the notebook you also need to install `notebook` using pip3. To launch jupyter notebook type ``jupyter notebook`` in the terminal.
+To run the examples locally you have to install windpowerlib. To run the notebook you also need to install `notebook` using pip3. To launch jupyter notebook type ``jupyter notebook`` in the terminal.
 This will open a browser window. Navigate to the directory containing the notebook to open it. See the jupyter notebook quick start guide for more information on `how to install <http://jupyter-notebook-beginner-guide.readthedocs.io/en/latest/install.html>`_ and
-`how to run <http://jupyter-notebook-beginner-guide.readthedocs.io/en/latest/execute.html>`_ jupyter notebooks.
+`how to run <http://jupyter-notebook-beginner-guide.readthedocs.io/en/latest/execute.html>`_ jupyter notebooks. In order to reproduce the figures in a notebook you need to install `matplotlib`.
 
 Further functionalities, like the modelling of wind farms and wind turbine clusters, are shown in the `TurbineClusterModelChain example <http://windpowerlib.readthedocs.io/en/stable/turbine_cluster_modelchain_example_notebook.html>`_. As the ModelChain example it is available as jupyter notebook and as python script. The weather and turbine datadata used in this example is the same as in the example above.
 
- * `TurbineClusterModelChain example (Python script) <https://raw.githubusercontent.com/wind-python/windpowerlib/master/example/turbine_cluster_modelchain_example.py>`_
- * `TurbineClusterModelChain example (Jupyter notebook) <https://raw.githubusercontent.com/wind-python/windpowerlib/master/example/turbine_cluster_modelchain_example.ipynb>`_
+* `TurbineClusterModelChain example (Python script) <https://raw.githubusercontent.com/wind-python/windpowerlib/master/example/turbine_cluster_modelchain_example.py>`_
+* `TurbineClusterModelChain example (Jupyter notebook) <https://raw.githubusercontent.com/wind-python/windpowerlib/master/example/turbine_cluster_modelchain_example.ipynb>`_
 
 You can also look at the examples in the `Examples section <http://windpowerlib.readthedocs.io/en/stable/examples.html>`_.
 

--- a/postBuild
+++ b/postBuild
@@ -1,0 +1,5 @@
+# Used by https://mybinder.org for setting up Docker container.
+#
+# setup.py does not specify matplotlib in ``install_requires``, therefore, in
+# order to produce plots in Binder install matplotlib:
+python -m pip install matplotlib


### PR DESCRIPTION
Changes proposed in this pull request:
- No changes to the API
- Add postBuild file to the repo which sets up docker session in Binder with matplotlib because windpowerlib doesn't come with matplotlib (this is now documented in README.rst)
- Add Binder badge and text in README.rst explaining how to run Binder (people that know about Binder will click on the badge on top)

This PR improves reproducibility of notebook examples. Binder is aimed for windpowerlib (and Python) beginners that would like to see how `windpowerlib` works in practice using the notebooks provided and don't want to install it locally.

To see how the README.rst with changes look like before merging, go to [binder-example](https://github.com/vezeli/windpowerlib/tree/binder-example) branch on my fork of windpowerlib. Start the jupyter session by clicking on the badge "launch binder" of the README page (or in the example section link) and jupyter page will open in a new tab in your browser.

Additionally, I removed problematic indentation in README.rst because it renders as quotation environment and now it renders as standard list.
