### PR TITLE
Features/allow data heigts of type string

### DIFF
--- a/tests/test_modelchain.py
+++ b/tests/test_modelchain.py
@@ -341,3 +341,26 @@ class TestModelChain:
                                 power_output_model='power_coefficient_curve')
         test_mc.run_model(self.weather_df)
         assert_series_equal(test_mc.power_output, power_output_exp)
+
+    def test_heigths_as_string(self):
+        """Test run_model if data heights are of type string."""
+        test_turbine = {'hub_height': 100,
+                        'rotor_diameter': 80,
+                        'turbine_type': 'E-126/4200'}
+
+        # Convert data heights to str
+        string_weather = self.weather_df.copy()
+        string_weather.columns = pd.MultiIndex.from_arrays([
+            string_weather.columns.get_level_values(0),
+            string_weather.columns.get_level_values(1).astype(str)])
+
+        # Heights in the original DataFrame are of type np.int64
+        assert isinstance(self.weather_df.columns.get_level_values(1)[0],
+                          np.int64)
+        assert isinstance(string_weather.columns.get_level_values(1)[0], str)
+
+        test_modelchain = {'power_output_model': 'power_curve',
+                           'density_corr': True}
+        test_mc = mc.ModelChain(wt.WindTurbine(**test_turbine),
+                                **test_modelchain)
+        test_mc.run_model(string_weather)

--- a/windpowerlib/modelchain.py
+++ b/windpowerlib/modelchain.py
@@ -442,7 +442,7 @@ class ModelChain(object):
         # Convert data heights to integer. In some case they are strings.
         weather_df.columns = pd.MultiIndex.from_arrays([
             weather_df.columns.get_level_values(0),
-            weather_df.columns.get_level_values(1).astype(int)])
+            pd.to_numeric(weather_df.columns.get_level_values(1))])
 
         wind_speed_hub = self.wind_speed_hub(weather_df)
         density_hub = (None if (self.power_output_model == 'power_curve' and

--- a/windpowerlib/modelchain.py
+++ b/windpowerlib/modelchain.py
@@ -7,6 +7,7 @@ SPDX-FileCopyrightText: 2019 oemof developer group <contact@oemof.org>
 SPDX-License-Identifier: MIT
 """
 import logging
+import pandas as pd
 from windpowerlib import (wind_speed, density, temperature, power_output,
                           tools)
 
@@ -438,6 +439,11 @@ class ModelChain(object):
         'wind_speed'
 
         """
+        # Convert data heights to integer. In some case they are strings.
+        weather_df.columns = pd.MultiIndex.from_arrays([
+            weather_df.columns.get_level_values(0),
+            weather_df.columns.get_level_values(1).astype(int)])
+
         wind_speed_hub = self.wind_speed_hub(weather_df)
         density_hub = (None if (self.power_output_model == 'power_curve' and
                                 self.density_correction is False)


### PR DESCRIPTION
Fix: #86 

The `read_csv()` function of pandas read column names as strings. In a weather file the second level of the columns are the data heights. These heights should be of type integer.

With this PR these values are converted into integer values.