### PR TITLE
Raise a warning if there are nan values in the weather data set

### DIFF
--- a/tests/test_modelchain.py
+++ b/tests/test_modelchain.py
@@ -435,38 +435,52 @@ class TestModelChain:
 
     def test_heigths_as_string(self):
         """Test run_model if data heights are of type string."""
-        test_turbine = {'hub_height': 100,
-                        'rotor_diameter': 80,
-                        'turbine_type': 'E-126/4200'}
+        test_turbine = {
+            "hub_height": 100,
+            "rotor_diameter": 80,
+            "turbine_type": "E-126/4200",
+        }
 
         # Convert data heights to str
         string_weather = self.weather_df.copy()
-        string_weather.columns = pd.MultiIndex.from_arrays([
-            string_weather.columns.get_level_values(0),
-            string_weather.columns.get_level_values(1).astype(str)])
+        string_weather.columns = pd.MultiIndex.from_arrays(
+            [
+                string_weather.columns.get_level_values(0),
+                string_weather.columns.get_level_values(1).astype(str),
+            ]
+        )
 
         # Heights in the original DataFrame are of type np.int64
-        assert isinstance(self.weather_df.columns.get_level_values(1)[0],
-                          np.int64)
+        assert isinstance(
+            self.weather_df.columns.get_level_values(1)[0], np.int64
+        )
         assert isinstance(string_weather.columns.get_level_values(1)[0], str)
 
-        test_modelchain = {'power_output_model': 'power_curve',
-                           'density_corr': True}
-        test_mc = mc.ModelChain(wt.WindTurbine(**test_turbine),
-                                **test_modelchain)
+        test_modelchain = {
+            "power_output_model": "power_curve",
+            "density_corr": True,
+        }
+        test_mc = mc.ModelChain(
+            wt.WindTurbine(**test_turbine), **test_modelchain
+        )
         test_mc.run_model(string_weather)
 
     def test_weather_with_nan_values(self, recwarn):
         """Test warning if weather data contain nan values."""
-        test_turbine = {'hub_height': 100,
-                        'rotor_diameter': 80,
-                        'turbine_type': 'E-126/4200'}
+        test_turbine = {
+            "hub_height": 100,
+            "rotor_diameter": 80,
+            "turbine_type": "E-126/4200",
+        }
         nan_weather = self.weather_df.copy()
         nan_weather.loc[1, ("temperature", 10)] = np.nan
-        test_modelchain = {'power_output_model': 'power_curve',
-                           'density_corr': True}
-        test_mc = mc.ModelChain(wt.WindTurbine(**test_turbine),
-                                **test_modelchain)
+        test_modelchain = {
+            "power_output_model": "power_curve",
+            "density_corr": True,
+        }
+        test_mc = mc.ModelChain(
+            wt.WindTurbine(**test_turbine), **test_modelchain
+        )
         msg = "'temperature', 10"
         with pytest.warns(WindpowerlibUserWarning, match=msg):
             test_mc.run_model(nan_weather)

--- a/tests/test_modelchain.py
+++ b/tests/test_modelchain.py
@@ -16,9 +16,9 @@ from windpowerlib.tools import WindpowerlibUserWarning
 
 class TestModelChain:
     @classmethod
-    def setup_class(self):
+    def setup_class(cls):
         """Setup default values"""
-        self.test_turbine = {
+        cls.test_turbine = {
             "hub_height": 100,
             "turbine_type": "E-126/4200",
             "power_curve": pd.DataFrame(
@@ -32,7 +32,7 @@ class TestModelChain:
         wind_speed_8m = np.array([[4.0], [5.0]])
         wind_speed_10m = np.array([[5.0], [6.5]])
         roughness_length = np.array([[0.15], [0.15]])
-        self.weather_df = pd.DataFrame(
+        cls.weather_df = pd.DataFrame(
             np.hstack(
                 (
                     temperature_2m,

--- a/windpowerlib/modelchain.py
+++ b/windpowerlib/modelchain.py
@@ -512,17 +512,7 @@ class ModelChain(object):
         'wind_speed'
 
         """
-        # Convert data heights to integer. In some case they are strings.
-        weather_df.columns = pd.MultiIndex.from_arrays([
-            weather_df.columns.get_level_values(0),
-            pd.to_numeric(weather_df.columns.get_level_values(1))])
-
-        if weather_df.isnull().any().any():
-            nan_columns = list(weather_df.columns[weather_df.isnull().any()])
-            msg = ("The following columns of the weather data contain invalid "
-                   "values like 'nan': {0}")
-            warnings.warn(msg.format(nan_columns),
-                          tools.WindpowerlibUserWarning)
+        weather_df = tools.check_weather_data(weather_df)
 
         wind_speed_hub = self.wind_speed_hub(weather_df)
         density_hub = (

--- a/windpowerlib/modelchain.py
+++ b/windpowerlib/modelchain.py
@@ -7,10 +7,8 @@ SPDX-FileCopyrightText: 2019 oemof developer group <contact@oemof.org>
 SPDX-License-Identifier: MIT
 """
 import logging
-import warnings
 import pandas as pd
-from windpowerlib import (wind_speed, density, temperature, power_output,
-                          tools)
+from windpowerlib import wind_speed, density, temperature, power_output, tools
 
 
 class ModelChain(object):

--- a/windpowerlib/modelchain.py
+++ b/windpowerlib/modelchain.py
@@ -7,6 +7,7 @@ SPDX-FileCopyrightText: 2019 oemof developer group <contact@oemof.org>
 SPDX-License-Identifier: MIT
 """
 import logging
+import warnings
 import pandas as pd
 from windpowerlib import (wind_speed, density, temperature, power_output,
                           tools)
@@ -515,6 +516,13 @@ class ModelChain(object):
         weather_df.columns = pd.MultiIndex.from_arrays([
             weather_df.columns.get_level_values(0),
             pd.to_numeric(weather_df.columns.get_level_values(1))])
+
+        if weather_df.isnull().any().any():
+            nan_columns = list(weather_df.columns[weather_df.isnull().any()])
+            msg = ("The following columns of the weather data contain invalid "
+                   "values like 'nan': {0}")
+            warnings.warn(msg.format(nan_columns),
+                          tools.WindpowerlibUserWarning)
 
         wind_speed_hub = self.wind_speed_hub(weather_df)
         density_hub = (

--- a/windpowerlib/tools.py
+++ b/windpowerlib/tools.py
@@ -7,6 +7,7 @@ SPDX-License-Identifier: MIT
 """
 import numpy as np
 import warnings
+import pandas as pd
 
 
 class WindpowerlibUserWarning(UserWarning):
@@ -221,3 +222,25 @@ def estimate_turbulence_intensity(height, roughness_length):
 
     """
     return 1 / (np.log(height / roughness_length))
+
+
+def check_weather_data(weather_df):
+    """
+    Check weather Data Frame.
+
+    - Raise warning if there are nan values.
+    - Convert columns if heights are string and not numeric.
+
+    """
+    # Convert data heights to integer. In some case they are strings.
+    weather_df.columns = pd.MultiIndex.from_arrays([
+        weather_df.columns.get_level_values(0),
+        pd.to_numeric(weather_df.columns.get_level_values(1))])
+
+    # check for nan values
+    if weather_df.isnull().any().any():
+        nan_columns = list(weather_df.columns[weather_df.isnull().any()])
+        msg = ("The following columns of the weather data contain invalid "
+               "values like 'nan': {0}")
+        warnings.warn(msg.format(nan_columns), WindpowerlibUserWarning)
+    return weather_df

--- a/windpowerlib/turbine_cluster_modelchain.py
+++ b/windpowerlib/turbine_cluster_modelchain.py
@@ -10,7 +10,7 @@ SPDX-License-Identifier: MIT
 import logging
 import pandas as pd
 from windpowerlib import wake_losses
-from windpowerlib.modelchain import ModelChain
+from windpowerlib.modelchain import ModelChain, tools
 
 
 class TurbineClusterModelChain(ModelChain):
@@ -289,10 +289,7 @@ class TurbineClusterModelChain(ModelChain):
         'wind_speed'
 
         """
-        # Convert data heights to integer. In some case they are strings.
-        weather_df.columns = pd.MultiIndex.from_arrays([
-            weather_df.columns.get_level_values(0),
-            pd.to_numeric(weather_df.columns.get_level_values(1))])
+        weather_df = tools.check_weather_data(weather_df)
 
         self.assign_power_curve(weather_df)
         self.power_plant.mean_hub_height()


### PR DESCRIPTION
Fixes #95.

Changes proposed in this pull request:

- If there are nan values in the weather data a warning will raised. The message includes which columns contain nan values.

- I moved the tests to the tools module, because the code would be duplicate (`ModelChain` and `TurbineClusterModelChain`)

I can add tests if you agree with this approach.

[ ] add tests

