### PR TITLE
Drop Python 3.5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 
 matrix:
   include:
-    - python: 3.5
     - python: 3.6
     - python: 3.7
     - python: 3.8

--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ Go to the `download page <http://readthedocs.org/projects/windpowerlib/downloads
 Installation
 ============
 
-If you have a working Python 3 environment, use pypi to install the latest windpowerlib version:
+If you have a working Python 3 (>= 3.6) environment, use pypi to install the latest windpowerlib version:
 
 ::
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 79
-target-version = ['py35', 'py36', 'py37', 'py38']
+target-version = ['py36', 'py37', 'py38']
 include = '\.pyi?$'
 exclude = '''
 /(


### PR DESCRIPTION
As 3.8 is published now, we could drop support for 3.5.