### PR TITLE
Use pure numpy arrays in power_output calculation (~x10 speedup for large datasets)

### DIFF
--- a/tests/test_power_output.py
+++ b/tests/test_power_output.py
@@ -215,10 +215,11 @@ class TestPowerOutput:
             power_curve(**self.parameters2), self.power_output_exp2
         )
 
-        # Raise TypeErrors due to wrong type of `density_correction`
-        with pytest.raises(TypeError):
-            parameters["density"] = "wrong_type"
-            power_curve(**parameters)
+    def test_power_curve_11(self):
+        """Raise IndexErrors due to wrong type of `density_correction`"""
+        with pytest.raises(IndexError, match="too many indices for array"):
+            self.parameters2["density"] = "wrong_type"
+            power_curve(**self.parameters2)
 
     def test_power_curve_density_correction(self):
         """TODO: Explain and split this test."""

--- a/tests/test_power_output.py
+++ b/tests/test_power_output.py
@@ -25,10 +25,25 @@ class TestPowerOutput:
             "power_coefficient_curve_wind_speeds": pd.Series([4.0, 5.0, 6.0]),
             "power_coefficient_curve_values": pd.Series([0.3, 0.4, 0.5]),
         }
+        self.parameters2: Dict = {
+            "wind_speed": pd.Series(data=[2.0, 5.5, 7.0]),
+            "density": pd.Series(data=[1.3, 1.3, 1.3]),
+            "density_correction": False,
+            "power_curve_wind_speeds": pd.Series([4.0, 5.0, 6.0]),
+            "power_curve_values": pd.Series([300, 400, 500]),
+        }
+        self.power_output_exp1 = pd.Series(
+            data=[0.0, 450.0, 0.0], name="feedin_power_plant"
+        )
+        self.power_output_exp2 = pd.Series(
+            data=[0.0, 461.00290572, 0.0], name="feedin_power_plant"
+        )
 
     def test_power_coefficient_curve_1(self):
-        # Test wind_speed as pd.Series with density and power_coefficient_curve
-        # as pd.Series and np.array
+        """
+        Test wind_speed as pd.Series with density and power_coefficient_curve
+        as pd.Series and np.array
+        """
         power_output_exp = pd.Series(
             data=[0.0, 244615.399, 0.0], name="feedin_power_plant"
         )
@@ -53,14 +68,20 @@ class TestPowerOutput:
         )
 
     def test_power_coefficient_curve_output_types(self):
-        parameters = self.parameters
-        # Test wind_speed as np.array with density and power_coefficient_curve
-        # as np.array and pd.Series
-        assert isinstance(power_coefficient_curve(**parameters), pd.Series)
-        parameters["wind_speed"] = np.array(parameters["wind_speed"])
-        assert isinstance(power_coefficient_curve(**parameters), np.ndarray)
+        """
+        Test wind_speed as np.array with density and power_coefficient_curve
+        as np.array and pd.Series
+        """
+        assert isinstance(
+            power_coefficient_curve(**self.parameters), pd.Series
+        )
+        self.parameters["wind_speed"] = np.array(self.parameters["wind_speed"])
+        assert isinstance(
+            power_coefficient_curve(**self.parameters), np.ndarray
+        )
 
     def test_power_coefficient_curve_2(self):
+        """TODO: Explain this test"""
         parameters = self.parameters
         power_output_exp = np.array([0.0, 244615.399, 0.0])
         parameters["wind_speed"] = np.array(parameters["wind_speed"])
@@ -83,79 +104,116 @@ class TestPowerOutput:
         )
         assert isinstance(power_coefficient_curve(**parameters), np.ndarray)
 
-    def test_power_curve(self):
-        parameters = {
-            "wind_speed": pd.Series(data=[2.0, 5.5, 7.0]),
-            "density": pd.Series(data=[1.3, 1.3, 1.3]),
-            "density_correction": False,
-            "power_curve_wind_speeds": pd.Series([4.0, 5.0, 6.0]),
-            "power_curve_values": pd.Series([300, 400, 500]),
-        }
-
+    def test_power_curve_1(self):
         # Tests without density correction:
         # Test wind_speed as pd.Series and power_curve as pd.Series and
         # np.array
-        power_output_exp = pd.Series(
-            data=[0.0, 450.0, 0.0], name="feedin_power_plant"
-        )
-        assert_series_equal(power_curve(**parameters), power_output_exp)
-        parameters["power_curve_values"] = np.array(
-            parameters["power_curve_values"]
-        )
-        parameters["power_curve_wind_speeds"] = np.array(
-            parameters["power_curve_wind_speeds"]
-        )
-        assert_series_equal(power_curve(**parameters), power_output_exp)
 
-        # Test wind_speed as np.array and power_curve as pd.Series and np.array
-        power_output_exp = np.array([0.0, 450.0, 0.0])
-        parameters["wind_speed"] = np.array(parameters["wind_speed"])
-        assert_allclose(power_curve(**parameters), power_output_exp)
-        assert isinstance(power_curve(**parameters), np.ndarray)
-        parameters["power_curve_wind_speeds"] = pd.Series(
-            data=parameters["power_curve_wind_speeds"]
+        assert_series_equal(
+            power_curve(**self.parameters2), self.power_output_exp1
         )
-        parameters["power_curve_values"] = pd.Series(
-            data=parameters["power_curve_values"]
-        )
-        assert_allclose(power_curve(**parameters), power_output_exp)
-        assert isinstance(power_curve(**parameters), np.ndarray)
 
-        # Tests with density correction:
-        # Test wind_speed as np.array with density and power_curve as pd.Series
-        # and np.array
-        power_output_exp = np.array([0.0, 461.00290572, 0.0])
-        parameters["density_correction"] = True
-        assert_allclose(power_curve(**parameters), power_output_exp)
-        assert isinstance(power_curve(**parameters), np.ndarray)
-        parameters["density"] = np.array(parameters["density"])
-        assert_allclose(power_curve(**parameters), power_output_exp)
-        assert isinstance(power_curve(**parameters), np.ndarray)
-        parameters["power_curve_values"] = np.array(
-            parameters["power_curve_values"]
+    def test_power_curve_2(self):
+        """TODO: Explain this test"""
+        self.parameters2["power_curve_values"] = np.array(
+            self.parameters2["power_curve_values"]
         )
-        parameters["power_curve_wind_speeds"] = np.array(
-            parameters["power_curve_wind_speeds"]
+        self.parameters2["power_curve_wind_speeds"] = np.array(
+            self.parameters2["power_curve_wind_speeds"]
         )
-        assert_allclose(power_curve(**parameters), power_output_exp)
-        assert isinstance(power_curve(**parameters), np.ndarray)
+        assert_series_equal(
+            power_curve(**self.parameters2), self.power_output_exp1
+        )
 
-        # Test wind_speed as pd.Series with density and power_curve as
-        # np. array and pd.Series
-        power_output_exp = pd.Series(
-            data=[0.0, 461.00290572, 0.0], name="feedin_power_plant"
+    def test_power_curve_3(self):
+        """
+        Test wind_speed as np.array and power_curve as
+        pd.Series and np.array
+        """
+        power_output_exp = np.array(self.power_output_exp1)
+        self.parameters2["wind_speed"] = np.array(
+            self.parameters2["wind_speed"]
         )
-        parameters["wind_speed"] = pd.Series(data=parameters["wind_speed"])
-        assert_series_equal(power_curve(**parameters), power_output_exp)
-        parameters["density"] = pd.Series(data=parameters["density"])
-        assert_series_equal(power_curve(**parameters), power_output_exp)
-        parameters["power_curve_wind_speeds"] = pd.Series(
-            data=parameters["power_curve_wind_speeds"]
+        assert_allclose(power_curve(**self.parameters2), power_output_exp)
+        assert isinstance(power_curve(**self.parameters2), np.ndarray)
+
+    def test_power_curve_4(self):
+        """TODO: Explain this test"""
+        self.parameters2["power_curve_wind_speeds"] = pd.Series(
+            data=self.parameters2["power_curve_wind_speeds"]
         )
-        parameters["power_curve_values"] = pd.Series(
-            data=parameters["power_curve_values"]
+        self.parameters2["power_curve_values"] = pd.Series(
+            data=self.parameters2["power_curve_values"]
         )
-        assert_series_equal(power_curve(**parameters), power_output_exp)
+        assert_allclose(
+            power_curve(**self.parameters2), self.power_output_exp1
+        )
+        assert isinstance(power_curve(**self.parameters2), np.ndarray)
+
+    def test_power_curve_5(self):
+        """
+        Tests with density correction:
+        Test wind_speed as np.array with density and power_curve as pd.Series
+        and np.array
+        """
+        power_output_exp = np.array(self.power_output_exp2)
+        self.parameters2["density_correction"] = True
+        assert_allclose(power_curve(**self.parameters2), power_output_exp)
+        assert isinstance(power_curve(**self.parameters2), np.ndarray)
+
+    def test_power_curve_6(self):
+        """TODO: Explain this test"""
+        self.parameters2["density"] = np.array(self.parameters2["density"])
+        assert_allclose(
+            power_curve(**self.parameters2), self.power_output_exp2
+        )
+        assert isinstance(power_curve(**self.parameters2), np.ndarray)
+
+    def test_power_curve_7(self):
+        """TODO: Explain this test"""
+        self.parameters2["power_curve_values"] = np.array(
+            self.parameters2["power_curve_values"]
+        )
+        self.parameters2["power_curve_wind_speeds"] = np.array(
+            self.parameters2["power_curve_wind_speeds"]
+        )
+        assert_allclose(
+            power_curve(**self.parameters2), self.power_output_exp2
+        )
+        assert isinstance(power_curve(**self.parameters2), np.ndarray)
+
+    def test_power_curve_8(self):
+        """
+        Test wind_speed as pd.Series with density and power_curve as np. array
+         and pd.Series
+        """
+        self.parameters2["wind_speed"] = pd.Series(
+            data=self.parameters2["wind_speed"]
+        )
+        assert_series_equal(
+            power_curve(**self.parameters2), self.power_output_exp2
+        )
+
+    def test_power_curve_9(self):
+        """TODO: Explain this test"""
+        self.parameters2["density"] = pd.Series(
+            data=self.parameters2["density"]
+        )
+        assert_series_equal(
+            power_curve(**self.parameters2), self.power_output_exp2
+        )
+
+    def test_power_curve_10(self):
+        """TODO: Explain this test"""
+        self.parameters2["power_curve_wind_speeds"] = pd.Series(
+            data=self.parameters2["power_curve_wind_speeds"]
+        )
+        self.parameters2["power_curve_values"] = pd.Series(
+            data=self.parameters2["power_curve_values"]
+        )
+        assert_series_equal(
+            power_curve(**self.parameters2), self.power_output_exp2
+        )
 
         # Raise TypeErrors due to wrong type of `density_correction`
         with pytest.raises(TypeError):
@@ -163,6 +221,7 @@ class TestPowerOutput:
             power_curve(**parameters)
 
     def test_power_curve_density_correction(self):
+        """TODO: Explain and split this test."""
         parameters = {
             "wind_speed": pd.Series(data=[2.0, 5.5, 7.0]),
             "density": pd.Series(data=[1.3, 1.3, 1.3]),

--- a/windpowerlib/power_output.py
+++ b/windpowerlib/power_output.py
@@ -249,9 +249,9 @@ def power_curve_density_correction(
 
     power_output = _get_power_output(
         wind_speed,
-        power_curve_wind_speeds.to_numpy(),
-        density.to_numpy(),
-        power_curve_values.to_numpy(),
+        np.array(power_curve_wind_speeds),
+        np.array(density),
+        np.array(power_curve_values),
     )
 
     # Convert results to the data type of the input data
@@ -271,23 +271,23 @@ def _get_power_output(
     """Get the power output at each timestep using only numpy to speed up performance
     Parameters
     ----------
-    wind_speed : :pandas:`pandas.Series<series>` or numpy.array
+    wind_speed : :numpy:`numpy.ndarray`
         Wind speed at hub height in m/s.
-    power_curve_wind_speeds : :pandas:`pandas.Series<series>` or numpy.array
+    power_curve_wind_speeds : :numpy:`numpy.ndarray`
         Wind speeds in m/s for which the power curve values are provided in
         `power_curve_values`.
-    power_curve_values : :pandas:`pandas.Series<series>` or numpy.array
+    density : :numpy:`numpy.ndarray`
+        Density of air at hub height in kg/m³.
+    power_curve_values : :numpy:`numpy.ndarray`
         Power curve values corresponding to wind speeds in
         `power_curve_wind_speeds`.
-    density : :pandas:`pandas.Series<series>` or numpy.array
-        Density of air at hub height in kg/m³.
     Returns
     -------
     :numpy:`numpy.array`
         Electrical power output of the wind turbine in W.
     """
-
     power_output = np.empty(len(wind_speed), dtype=np.float)
+
     for i in range(len(wind_speed)):
         power_output[i] = np.interp(
             wind_speed[i],

--- a/windpowerlib/power_output.py
+++ b/windpowerlib/power_output.py
@@ -247,8 +247,12 @@ def power_curve_density_correction(
     else:
         panda_series = False
 
-    power_output = _get_power_output(wind_speed, power_curve_wind_speeds.to_numpy(
-    ), density.to_numpy(), power_curve_values.to_numpy())
+    power_output = _get_power_output(
+        wind_speed,
+        power_curve_wind_speeds.to_numpy(),
+        density.to_numpy(),
+        power_curve_values.to_numpy(),
+    )
 
     # Convert results to the data type of the input data
     if panda_series:
@@ -261,8 +265,10 @@ def power_curve_density_correction(
     return power_output
 
 
-def _get_power_output(wind_speed, power_curve_wind_speeds, density, power_curve_values):
-    """ Get the power output at each timestep using only numpy to speed up performance
+def _get_power_output(
+    wind_speed, power_curve_wind_speeds, density, power_curve_values
+):
+    """Get the power output at each timestep using only numpy to speed up performance
     Parameters
     ----------
     wind_speed : :pandas:`pandas.Series<series>` or numpy.array
@@ -283,19 +289,15 @@ def _get_power_output(wind_speed, power_curve_wind_speeds, density, power_curve_
 
     power_output = np.empty(len(wind_speed), dtype=np.float)
     for i in range(len(wind_speed)):
-        power_output[i] = (
-            np.interp(
-                wind_speed[i],
-                power_curve_wind_speeds
-                * (1.225 / density[i])
-                ** (
-                    np.interp(
-                        power_curve_wind_speeds, [7.5, 12.5], [1 / 3, 2 / 3]
-                    )
-                ),
-                power_curve_values,
-                left=0,
-                right=0,
-            )
+        power_output[i] = np.interp(
+            wind_speed[i],
+            power_curve_wind_speeds
+            * (1.225 / density[i])
+            ** (
+                np.interp(power_curve_wind_speeds, [7.5, 12.5], [1 / 3, 2 / 3])
+            ),
+            power_curve_values,
+            left=0,
+            right=0,
         )
     return power_output

--- a/windpowerlib/power_output.py
+++ b/windpowerlib/power_output.py
@@ -247,7 +247,8 @@ def power_curve_density_correction(
     else:
         panda_series = False
 
-    power_output = _get_power_output(wind_speed, power_curve_wind_speeds.to_numpy(), density.to_numpy(), power_curve_values.to_numpy())
+    power_output = _get_power_output(wind_speed, power_curve_wind_speeds.to_numpy(
+    ), density.to_numpy(), power_curve_values.to_numpy())
 
     # Convert results to the data type of the input data
     if panda_series:
@@ -276,7 +277,7 @@ def _get_power_output(wind_speed, power_curve_wind_speeds, density, power_curve_
         Density of air at hub height in kg/m³.
     Returns
     -------
-    :numpy: `numpy.array`
+    :numpy:`numpy.array`
         Electrical power output of the wind turbine in W.
     """
 


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
- Use of pure numpy arrays in the power output calculation in power_output.power_curve_density_correction(). On a ~220,000 timestamps dataset, the computation time was reduced from 50 seconds to ~3 seconds.

