### PR TITLE
Vectorize _get_power_output calculations

### DIFF
--- a/windpowerlib/power_output.py
+++ b/windpowerlib/power_output.py
@@ -294,9 +294,11 @@ def _get_power_output(
     ) * power_curve_wind_speeds
 
     # Create the interpolation function
-    interp_func = lambda w_speed, p_curves: np.interp(
-        w_speed, p_curves, power_curve_values, left=0, right=0
-    )
+    def interp_func(w_speed, p_curves):
+        return np.interp(
+            w_speed, p_curves, power_curve_values, left=0, right=0
+        )
+
     # Calculate the power output by mapping the arrays to the interp function
     power_output = np.array(
         list(map(interp_func, wind_speed, power_curves_per_ts))

--- a/windpowerlib/power_output.py
+++ b/windpowerlib/power_output.py
@@ -286,15 +286,11 @@ def _get_power_output(
     :numpy:`numpy.array`
         Electrical power output of the wind turbine in W.
     """
-    # Create a new empty power curves array which which can be used t
-    power_curve_exponent = np.interp(
-        power_curve_wind_speeds, [7.5, 12.5], [1 / 3, 2 / 3]
-    )
-
     # Calculate the power curves for each timestep using vectors
     # NOTE: power_curves_per_ts.shape = [len(wind_speed), len(density)]
     power_curves_per_ts = (
-        (1.225 / density).reshape(-1, 1) ** power_curve_exponent
+        (1.225 / density).reshape(-1, 1)
+        ** np.interp(power_curve_wind_speeds, [7.5, 12.5], [1 / 3, 2 / 3])
     ) * power_curve_wind_speeds
 
     # Create the interpolation function


### PR DESCRIPTION
This PR reduces the time computation required for the power_curve_density_correction function by vectorizing the calculations in the `_get_power_output` function.

On a dataset with around ~200k datapoints, the computation time was reduced from ~6seconds to ~2seconds. This might help speed up computation even more when larger datasets are used.

Changes proposed in this pull request:
- Use of vectorized numpy functions along with `map()` to speed up the `power_curve_density_correction` function
