### PR TITLE
add default_turbine_data to pip install package_data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ setup(
     packages=["windpowerlib"],
     package_data={
         "windpowerlib": [
-            os.path.join("data", "*.csv"),
+            os.path.join("data", "**.csv"),
+            os.path.join("data", "default_turbine_data", "*.csv"),
             os.path.join("oedb", "*.csv"),
         ]
     },


### PR DESCRIPTION
Fixes #127 
Fixes #119

Changes proposed in this pull request:
* add default_turbine_data to installation

Can be tested with: 

`!pip install git+https://github.com/maurerle/windpowerlib@fix_install_data`

